### PR TITLE
Support auto-completion for contents of npm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Provides path completion for visual studio code.
 - it supports absolute path to the workspace (starting with /)
 - it supports absolute path to the file system (starts with: C:)
 - it supports paths relative to the user folder (starts with ~)
+- it supports npm packages (starting with a-z and not relative to disk)
 
 ## Installation
 You can install it from the [marketplace](https://marketplace.visualstudio.com/items?itemName=ionutvmi.path-autocomplete).

--- a/src/features/PathAutocompleteProvider.ts
+++ b/src/features/PathAutocompleteProvider.ts
@@ -103,6 +103,11 @@ export class PathAutocomplete implements vs.CompletionItemProvider {
             return path.join(homeDir, insertedPath.substring(1));
         }
 
+        // npm package
+        if (insertedPath.match(/^[a-z]/i)) {
+            return path.join(vs.workspace.rootPath, 'node_modules', insertedPath);
+        }
+
         return path.join(currentDir, insertedPath);
     }
 


### PR DESCRIPTION
This PR returns the node_modules folder of the selected package if appropriate, enabling path suggestions for the contents of the package.