### PR TITLE
Add option to use path autocompletion outside strings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
           "type": "array",
           "default": [],
           "description": "Custom transformations applied to the inserted text."
+        },
+        "path-autocomplete.triggerOutsideStrings": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables path autocompletion outside strings."
         }
       }
     }


### PR DESCRIPTION
Some time ago we talked about this issue in #8. You mentioned problems with how the already inserted path is determined and that it may trigger in unwanted situations like typing `2 / 3`.

Here is my idea of solving this. Completion outside strings is disabled by default and requires setting a config option to `true`.

If the cursor is located inside a string (ie quotes) the inserted path starts at the beginning of these quotes, similar to the way `shouldProvide` works. Outside quotes the last *WORD* before the cursor is used as inserted path.

Please have a look at my implementation and reconsider adding this feature.