### PR TITLE
Fix scanDir error

### DIFF
--- a/src/features/PathAutocompleteProvider.ts
+++ b/src/features/PathAutocompleteProvider.ts
@@ -47,6 +47,10 @@ export class PathAutocomplete implements vs.CompletionItemProvider {
 
         var folderPath = this.getFolderPath(document.fileName, currentLine, position.character);
 
+        if (!fs.existsSync(folderPath) || !fs.lstatSync(folderPath).isDirectory()) {
+            return Promise.resolve([]);
+        }
+
         return this.getFolderItems(folderPath).then((items: FileInfo[]) => {
             // build the list of the completion items
             var result = items.filter(self.filter, self).map((file) => {


### PR DESCRIPTION
Triggering autocompletion when the string before the cursor is not a
valid path causes an error which does not directly trace back to this
extension.

This addtion guards the execution of the internal scanDir function to
only trigger for valid paths.