### PR TITLE
fix same prefix mappingkey cause path autocompleted error

### DIFF
--- a/src/features/PathAutocompleteProvider.ts
+++ b/src/features/PathAutocompleteProvider.ts
@@ -293,6 +293,15 @@ export class PathAutocomplete implements vs.CompletionItemProvider {
         var items = [];
 
         Object.keys(configuration.data.pathMappings || {})
+            // if insertedPath is '@view/'
+            // and mappings is [{key: '@', ...}, {key: '@view', ...}]
+            // and it will match '@' and return wrong items { currentDir: 'xxx',  insertedPath: 'view/'}
+            // solution : Sort keys by matching longest prefix, and it will match key(@view) first
+            .sort((key1, key2) => {
+                const f1 = insertedPath.startsWith(key1) ? key1.length : 0;
+                const f2 = insertedPath.startsWith(key2) ? key2.length : 0;
+                return f2 - f1;
+            })
             .map((key) => {
                 var candidatePaths = configuration.data.pathMappings[key];
 


### PR DESCRIPTION
### if use same prefix key will cause problem

// .setting.json
```
"path-autocomplete.pathMappings": {
    "@": "${folder}/src",
    "@view": "${folder}/src/components",
  },
```

`@` works fine, but `@view` not, i read source code and find `@view` will match `@` first and return wrong item

```
mappings.forEach(mapping => {
     if (insertedPath.startsWith(mapping.key) || (mapping.key === '$root' && !insertedPath.startsWith('.'))) {
// { currentDir:  '${folder}/src', insertedPath: 'view/' } wrong
         items.push({
             currentDir: mapping.path,
             insertedPath: insertedPath.replace(mapping.key, '')
          });
          found = true;

}
 });
```

### solution:

sort pathMappings key by matching longest prefix and it works

```
applyMapping(insertedPath: string): { items } {
...
Object.keys(configuration.data.pathMappings || {})
            // if insertedPath is '@view/'
            // and mappings is [{key: '@', ...}, {key: '@view', ...}]
            // and it will match '@' and return wrong items { currentDir: 'xxx',  insertedPath: 'view/'}
            // solution : Sort keys by matching longest prefix, and it will match key(@view) first
            .sort((key1, key2) => {
                const f1 = insertedPath.startsWith(key1)
                const f2 = insertedPath.startsWith(key2)
                if (f1 && f2) {
                    return key2.length - key1.length
                } else if (f1) {
                    return -1
                } else if (f2) {
                    return 1
                }
                return 0
            })
.map(...)
...
```
