### PR TITLE
Fix incorrect behavior when dealing with absolute paths.

### DIFF
--- a/src/features/PathAutocompleteProvider.ts
+++ b/src/features/PathAutocompleteProvider.ts
@@ -215,7 +215,12 @@ export class PathAutocomplete implements vs.CompletionItemProvider {
 
             // relative to the disk
             if (insertedPath.match(/^[a-z]:/i)) {
-                return [path.resolve(insertedPath)];
+                var resolved = path.resolve(insertedPath);
+                // restore trailing slashes if they were removed
+                if (resolved.slice(-1) != insertedPath.slice(-1)) {
+                    resolved += insertedPath.substr(-1);
+                }
+                return [resolved];
             }
 
             // user folder


### PR DESCRIPTION
Autocomplete suggestions for absolute paths are currently broken (on Windows at least). After a bit of investigating I found the culprit to be the `path.resolve()` function. This function removes trailing slashes from the path, which will cause the following `path.dirname()` call to return a directory an additional level up than intended.

e.g. currently if you have a folder setup like
`C:/Test1/Test2/Test3/`
And you trigger autocomplete suggestions at
`C:/Test1/Test2/`
The code will call `resolve()` on the string, resulting in `C:/Test1/Test2`, and then `dirname()` on that, resulting in `C:/Test1`. So then your autocomplete suggestion lists `/Test2` instead of the expected `/Test3`.

